### PR TITLE
Program Errors if space in path

### DIFF
--- a/scripts/exercise.js
+++ b/scripts/exercise.js
@@ -42,12 +42,12 @@ chokidar.watch(exerciseFile).on("all", (event, path) => {
     console.clear();
     if (containsVitest) {
       console.log("Running tests...");
-      execSync(`vitest run ${exerciseFile} --passWithNoTests`, {
+      execSync(`vitest run "${exerciseFile}" --passWithNoTests`, {
         stdio: "inherit",
       });
     }
     console.log("Checking types...");
-    execSync(`tsc ${exerciseFile} --noEmit --strict`, {
+    execSync(`tsc "${exerciseFile}" --noEmit --strict`, {
       stdio: "inherit",
     });
     console.log("Typecheck complete. You finished the exercise!");


### PR DESCRIPTION
I noticed that the program wouldn't work as expected if there was a space in the `exerciseFile` path so I wrapped it in quotes to ensure the command runs without error.

To replicate this error simple clone this repo into a folder with a space in the name (ex: "untitled folder"), install the packages, and run `yarn e 01`. 